### PR TITLE
修复 Markdown 预览格式丢失问题

### DIFF
--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -191,7 +191,28 @@ const MarkdownPreview = ({ content, images = [], className = '' }: MarkdownPrevi
       </CardHeader>
       <CardContent className="p-4 max-h-[500px] overflow-y-auto">
         <div 
-          className="prose prose-sm max-w-none prose-headings:text-gray-900 prose-p:text-gray-700 prose-a:text-blue-600 prose-strong:text-gray-900 prose-code:text-purple-600 prose-code:bg-purple-50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-gray-50 prose-pre:border prose-blockquote:border-l-4 prose-blockquote:border-blue-300 prose-blockquote:bg-blue-50/30 prose-table:text-sm prose-th:bg-gray-100 prose-img:rounded-lg prose-img:shadow-md"
+          className="prose prose-sm max-w-none 
+            prose-headings:text-gray-900 prose-headings:font-bold
+            prose-h1:text-2xl prose-h1:border-b prose-h1:border-gray-200 prose-h1:pb-2 prose-h1:mb-4
+            prose-h2:text-xl prose-h2:border-b prose-h2:border-gray-100 prose-h2:pb-1 prose-h2:mb-3
+            prose-h3:text-lg prose-h3:mb-2
+            prose-h4:text-base prose-h4:mb-2
+            prose-h5:text-sm prose-h5:mb-1
+            prose-h6:text-sm prose-h6:mb-1
+            prose-p:text-gray-700 prose-p:leading-relaxed prose-p:mb-4
+            prose-a:text-blue-600 prose-a:underline prose-a:decoration-blue-300 hover:prose-a:decoration-blue-500
+            prose-strong:text-gray-900 prose-strong:font-semibold
+            prose-em:text-gray-700 prose-em:italic
+            prose-code:text-purple-600 prose-code:bg-purple-50 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:font-mono
+            prose-pre:bg-gray-50 prose-pre:border prose-pre:border-gray-200 prose-pre:rounded-lg prose-pre:p-4 prose-pre:overflow-x-auto
+            prose-blockquote:border-l-4 prose-blockquote:border-blue-300 prose-blockquote:bg-blue-50/30 prose-blockquote:pl-4 prose-blockquote:py-2 prose-blockquote:italic
+            prose-ul:my-4 prose-ul:pl-6 prose-li:my-1 prose-li:marker:text-blue-500
+            prose-ol:my-4 prose-ol:pl-6 prose-ol:marker:text-blue-500 prose-ol:marker:font-semibold
+            prose-table:text-sm prose-table:border-collapse prose-table:w-full
+            prose-th:bg-gray-100 prose-th:border prose-th:border-gray-300 prose-th:px-3 prose-th:py-2 prose-th:text-left prose-th:font-semibold
+            prose-td:border prose-td:border-gray-200 prose-td:px-3 prose-td:py-2
+            prose-img:rounded-lg prose-img:shadow-md prose-img:max-w-full prose-img:h-auto
+            prose-hr:border-gray-300 prose-hr:my-6"
           dangerouslySetInnerHTML={{ __html: renderedHtml }}
         />
       </CardContent>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -92,5 +92,10 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+	plugins: [
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		require("tailwindcss-animate"), 
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		require("@tailwindcss/typography")
+	],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- 修复了 Markdown 预览中标题、段落等格式元素丢失的问题
- 启用了 Tailwind CSS Typography 插件，确保 prose 类正常工作
- 优化了各种 Markdown 元素的样式配置，提升视觉效果

## Changes
- **tailwind.config.ts**: 添加 @tailwindcss/typography 插件
- **MarkdownPreview.tsx**: 大幅改进样式配置，包括：
  - 标题格式：不同级别的标题现在有正确的大小、边框和间距
  - 段落格式：改善了行间距和边距
  - 列表格式：无序和有序列表有了正确的缩进和标记样式
  - 代码格式：行内代码和代码块有了更好的背景色和边框
  - 引用格式：块引用有了左边框和背景色
  - 表格格式：表格有了边框和背景色
  - 图片格式：图片有了圆角和阴影效果

## Test plan
- [x] 项目构建成功
- [x] 开发服务器正常启动
- [ ] 验证各种 Markdown 格式元素在预览中正确显示
- [ ] 测试不同类型的文档（包含标题、列表、代码块等）

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Enable the Tailwind CSS Typography plugin and revamp MarkdownPreview styling to properly render and improve the appearance of various Markdown elements

New Features:
- Enable Tailwind CSS Typography plugin for Markdown preview

Enhancements:
- Overhaul prose styling in MarkdownPreview to restore and enhance formatting for headings, paragraphs, links, emphasis, inline code, code blocks, blockquotes, lists, tables, images, and horizontal rules

Build:
- Add @tailwindcss/typography plugin to tailwind.config.ts alongside existing plugins