### PR TITLE
添加原始文本编辑功能

### DIFF
--- a/src/components/OcrResults.tsx
+++ b/src/components/OcrResults.tsx
@@ -1,9 +1,10 @@
-import { Copy, FileText, Download, Image as ImageIcon, Archive, Eye } from 'lucide-react';
+import { Copy, FileText, Download, Image as ImageIcon, Archive, Eye, Edit, Save, X } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToast } from '@/hooks/use-toast';
+import { useState, useEffect } from 'react';
 import JSZip from 'jszip';
 import MarkdownPreview from '@/components/MarkdownPreview';
 
@@ -17,14 +18,48 @@ interface ExtractedImage {
 interface OcrResultsProps {
   result: string;
   images?: ExtractedImage[];
+  onResultChange?: (newResult: string) => void;
 }
 
-const OcrResults = ({ result, images = [] }: OcrResultsProps) => {
+const OcrResults = ({ result, images = [], onResultChange }: OcrResultsProps) => {
   const { toast } = useToast();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editableText, setEditableText] = useState(result);
+
+  // 当result改变时同步更新editableText
+  useEffect(() => {
+    setEditableText(result);
+  }, [result]);
+
+  const handleEditToggle = () => {
+    if (isEditing) {
+      // 保存编辑
+      if (onResultChange) {
+        onResultChange(editableText);
+      }
+      toast({
+        title: "保存成功",
+        description: "文本修改已保存"
+      });
+    }
+    setIsEditing(!isEditing);
+  };
+
+  const handleCancelEdit = () => {
+    setEditableText(result); // 恢复原始内容
+    setIsEditing(false);
+    toast({
+      title: "取消编辑",
+      description: "已恢复原始内容"
+    });
+  };
+
+  // 获取当前显示的文本（编辑模式下使用editableText，否则使用result）
+  const currentText = isEditing ? editableText : result;
 
   const copyToClipboard = async () => {
     try {
-      await navigator.clipboard.writeText(result);
+      await navigator.clipboard.writeText(currentText);
       toast({
         title: "复制成功",
         description: "识别结果已复制到剪贴板"
@@ -39,7 +74,7 @@ const OcrResults = ({ result, images = [] }: OcrResultsProps) => {
   };
 
   const downloadText = () => {
-    const blob = new Blob([result], { type: 'text/markdown' });
+    const blob = new Blob([currentText], { type: 'text/markdown' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -60,7 +95,7 @@ const OcrResults = ({ result, images = [] }: OcrResultsProps) => {
       const zip = new JSZip();
       
       // 添加文字文件（Markdown 格式）
-      zip.file('ocr-result.md', result);
+      zip.file('ocr-result.md', currentText);
       
       // 添加图片文件
       if (images.length > 0) {
@@ -251,17 +286,59 @@ const OcrResults = ({ result, images = [] }: OcrResultsProps) => {
               </TabsList>
               
               <TabsContent value="text" className="mt-4">
-                <Textarea
-                  value={result}
-                  readOnly
-                  className="min-h-[400px] md:min-h-[500px] w-full resize-none border-gray-300 focus:border-blue-500 focus:ring-blue-500 bg-white text-sm font-mono"
-                  placeholder="识别结果将显示在这里..."
-                />
+                <div className="relative">
+                  {/* 编辑按钮区域 */}
+                  <div className="absolute top-2 right-2 z-10 flex gap-2">
+                    {isEditing ? (
+                      <>
+                        <Button
+                          onClick={handleEditToggle}
+                          variant="outline"
+                          size="sm"
+                          className="flex items-center space-x-1 bg-green-50 hover:bg-green-100 border-green-300 text-green-700 hover:text-green-800"
+                        >
+                          <Save className="w-3 h-3" />
+                          <span className="hidden sm:inline">保存</span>
+                        </Button>
+                        <Button
+                          onClick={handleCancelEdit}
+                          variant="outline"
+                          size="sm"
+                          className="flex items-center space-x-1 bg-gray-50 hover:bg-gray-100 border-gray-300 text-gray-700 hover:text-gray-800"
+                        >
+                          <X className="w-3 h-3" />
+                          <span className="hidden sm:inline">取消</span>
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        onClick={handleEditToggle}
+                        variant="outline"
+                        size="sm"
+                        className="flex items-center space-x-1 bg-blue-50 hover:bg-blue-100 border-blue-300 text-blue-700 hover:text-blue-800"
+                        disabled={!result.trim()}
+                      >
+                        <Edit className="w-3 h-3" />
+                        <span className="hidden sm:inline">编辑</span>
+                      </Button>
+                    )}
+                  </div>
+                  
+                  <Textarea
+                    value={isEditing ? editableText : result}
+                    onChange={(e) => isEditing && setEditableText(e.target.value)}
+                    readOnly={!isEditing}
+                    className={`min-h-[400px] md:min-h-[500px] w-full resize-none border-gray-300 focus:border-blue-500 focus:ring-blue-500 text-sm font-mono pr-20 ${
+                      isEditing ? 'bg-white' : 'bg-gray-50'
+                    }`}
+                    placeholder="识别结果将显示在这里..."
+                  />
+                </div>
               </TabsContent>
               
               <TabsContent value="preview" className="mt-4">
                 <MarkdownPreview 
-                  content={result} 
+                  content={currentText} 
                   images={images}
                   className="min-h-[400px]"
                 />

--- a/src/components/OcrResults.tsx
+++ b/src/components/OcrResults.tsx
@@ -34,13 +34,14 @@ const OcrResults = ({ result, images = [], onResultChange }: OcrResultsProps) =>
   const handleEditToggle = () => {
     if (isEditing) {
       // 保存编辑
-      if (onResultChange) {
+      if (onResultChange && editableText !== result) {
         onResultChange(editableText);
+        toast({
+          title: "保存成功",
+          description: "文本修改已保存"
+        });
       }
-      toast({
-        title: "保存成功",
-        description: "文本修改已保存"
-      });
+      // 如果文本没有改变，不显示保存成功的提示
     }
     setIsEditing(!isEditing);
   };
@@ -316,7 +317,7 @@ const OcrResults = ({ result, images = [], onResultChange }: OcrResultsProps) =>
                         variant="outline"
                         size="sm"
                         className="flex items-center space-x-1 bg-blue-50 hover:bg-blue-100 border-blue-300 text-blue-700 hover:text-blue-800"
-                        disabled={!result.trim()}
+                        disabled={!result || !result.trim()}
                       >
                         <Edit className="w-3 h-3" />
                         <span className="hidden sm:inline">编辑</span>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -522,7 +522,11 @@ const Index = () => {
 
           {/* Right Column - OCR Results */}
           <div className="xl:col-span-3 lg:col-span-2">
-            <OcrResults result={ocrResult} images={extractedImages} />
+            <OcrResults 
+              result={ocrResult} 
+              images={extractedImages} 
+              onResultChange={setOcrResult}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 在原始文本区域添加编辑按钮，允许用户编辑OCR识别结果
- 默认状态下文本为只读模式，点击编辑按钮可切换为编辑模式
- 编辑模式下提供保存和取消操作按钮
- 编辑后的文本与预览标签页保持实时同步

## 功能特性
- **编辑按钮**: 原始文本区域右上角添加编辑按钮
- **状态切换**: 支持只读和编辑模式间的切换
- **双按钮操作**: 编辑模式下显示保存和取消按钮
- **实时同步**: 编辑的文本立即在预览标签页中生效
- **完整集成**: 复制、下载等功能使用当前编辑的文本

## 技术实现
- 使用React状态管理编辑状态和文本内容
- 添加`onResultChange`回调支持文本更新
- 改进用户界面，提供直观的编辑体验
- 保持与现有功能的完全兼容

## Test plan
- [x] 编辑按钮在有文本时可用，无文本时禁用
- [x] 编辑模式下可以修改文本内容
- [x] 保存按钮将更改保存到主状态
- [x] 取消按钮恢复原始内容
- [x] 预览标签页实时显示编辑的文本
- [x] 复制和下载功能使用当前文本
- [x] 构建通过，无TypeScript错误

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Enable inline editing of OCR results by adding an edit mode with save and cancel controls, and keep all downstream features in sync with the edited text.

New Features:
- Add an edit button to the OCR result textarea to toggle between read-only and editable states with save and cancel actions
- Synchronize the edited text in real time to the preview tab and ensure copy, download, and ZIP export use the updated content
- Introduce an onResultChange callback to propagate saved edits back to the parent state