### PR TITLE
修复编辑状态在新任务识别时未重置的bug

### DIFF
--- a/src/components/OcrResults.tsx
+++ b/src/components/OcrResults.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToast } from '@/hooks/use-toast';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import JSZip from 'jszip';
 import MarkdownPreview from '@/components/MarkdownPreview';
 
@@ -25,11 +25,11 @@ const OcrResults = ({ result, images = [], onResultChange }: OcrResultsProps) =>
   const { toast } = useToast();
   const [isEditing, setIsEditing] = useState(false);
   const [editableText, setEditableText] = useState(result);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // 当result改变时同步更新editableText并重置编辑状态
+  // 当result改变时同步更新editableText
   useEffect(() => {
     setEditableText(result);
-    setIsEditing(false); // 重置为只读模式
   }, [result]);
 
   const handleEditToggle = () => {
@@ -42,7 +42,10 @@ const OcrResults = ({ result, images = [], onResultChange }: OcrResultsProps) =>
           description: "文本修改已保存"
         });
       }
-      // 如果文本没有改变，不显示保存成功的提示
+      // 退出编辑模式时失去焦点
+      if (textareaRef.current) {
+        textareaRef.current.blur();
+      }
     }
     setIsEditing(!isEditing);
   };
@@ -50,6 +53,10 @@ const OcrResults = ({ result, images = [], onResultChange }: OcrResultsProps) =>
   const handleCancelEdit = () => {
     setEditableText(result); // 恢复原始内容
     setIsEditing(false);
+    // 取消编辑时失去焦点
+    if (textareaRef.current) {
+      textareaRef.current.blur();
+    }
     toast({
       title: "取消编辑",
       description: "已恢复原始内容"
@@ -327,6 +334,7 @@ const OcrResults = ({ result, images = [], onResultChange }: OcrResultsProps) =>
                   </div>
                   
                   <Textarea
+                    ref={textareaRef}
                     value={isEditing ? editableText : result}
                     onChange={(e) => isEditing && setEditableText(e.target.value)}
                     readOnly={!isEditing}

--- a/src/components/OcrResults.tsx
+++ b/src/components/OcrResults.tsx
@@ -26,9 +26,10 @@ const OcrResults = ({ result, images = [], onResultChange }: OcrResultsProps) =>
   const [isEditing, setIsEditing] = useState(false);
   const [editableText, setEditableText] = useState(result);
 
-  // 当result改变时同步更新editableText
+  // 当result改变时同步更新editableText并重置编辑状态
   useEffect(() => {
     setEditableText(result);
+    setIsEditing(false); // 重置为只读模式
   }, [result]);
 
   const handleEditToggle = () => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -523,6 +523,7 @@ const Index = () => {
           {/* Right Column - OCR Results */}
           <div className="xl:col-span-3 lg:col-span-2">
             <OcrResults 
+              key={ocrResult ? ocrResult.slice(0, 100) + ocrResult.length : 'empty'}
               result={ocrResult} 
               images={extractedImages} 
               onResultChange={setOcrResult}


### PR DESCRIPTION
- 当识别新任务时，自动退出编辑模式回到只读状态
- 避免用户在编辑模式下识别新内容时状态混乱
- 改善用户体验，确保每次新识别都从清洁状态开始

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Fix editing state not resetting to read-only when a new task is recognized